### PR TITLE
Fix no-preprompt issue

### DIFF
--- a/src/ai_core.py
+++ b/src/ai_core.py
@@ -119,7 +119,16 @@ class NeoAI:
     def _query_lm_studio(self, prompt, clear_thinking=False):
         instruction = f"{self.lm_studio_config.get('input_prefix', '### Instruction:')} {prompt} {self.lm_studio_config.get('input_suffix', '### Response:')}"
 
-        messages = self.history.copy()
+        messages = []
+
+        # LM Studio models often expect only 'user' and 'assistant' roles.
+        # Convert any 'system' messages to 'user' to avoid template errors.
+        for msg in self.history:
+            role = msg.get("role", "user")
+            if role == "system":
+                role = "user"
+            messages.append({"role": role, "content": msg.get("content", "")})
+
         messages.append({"role": "user", "content": instruction})
 
         try:

--- a/src/ai_core.py
+++ b/src/ai_core.py
@@ -58,6 +58,23 @@ class NeoAI:
 
         self.lm_studio_config = config.get("lm_studio_config", {})
         self.history = []
+
+        # Inject pre-prompt instructions so the language model knows about the
+        # Machine Communication Protocol (MCP).  Without this, local models may
+        # respond like a regular chat bot and never issue command tags.
+        preprompt_path = os.path.join(
+            os.path.dirname(os.path.dirname(__file__)),
+            "config",
+            "PrePromt.md",
+        )
+        if os.path.exists(preprompt_path):
+            try:
+                with open(preprompt_path, "r") as f:
+                    preprompt_text = f.read()
+                self.history.append({"role": "system", "content": preprompt_text})
+            except Exception as e:
+                logging.error(f"Failed to load pre-prompt: {e}")
+
         self.context_initialized = False
 
     def _ensure_valid_token(self):


### PR DESCRIPTION
## Summary
- load pre-prompt file on startup so models know about the MCP command tags

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684819111e08832f8c29b52c3b2c281b